### PR TITLE
[chores] Fix collections ABCs deprecation warning

### DIFF
--- a/pythia/common/report.py
+++ b/pythia/common/report.py
@@ -14,10 +14,10 @@ class Report(OrderedDict):
 
         all_args = [batch, model_output] + [*args]
         for idx, arg in enumerate(all_args):
-            if not isinstance(arg, collections.Mapping):
+            if not isinstance(arg, collections.abc.Mapping):
                 raise TypeError(
                     "Argument {:d}, {} must be of instance of "
-                    "collections.Mapping".format(idx, arg)
+                    "collections.abc.Mapping".format(idx, arg)
                 )
 
         self.writer = registry.get("writer")
@@ -40,7 +40,7 @@ class Report(OrderedDict):
                 self[key] = item
 
     def _check_and_load_tuple(self, batch):
-        if isinstance(batch, collections.Mapping):
+        if isinstance(batch, collections.abc.Mapping):
             return False
 
         if isinstance(batch[0], (tuple, list)) and isinstance(batch[0][0], str):

--- a/pythia/common/sample.py
+++ b/pythia/common/sample.py
@@ -113,7 +113,7 @@ class SampleList(OrderedDict):
 
                 self[field][idx] = self._get_data_copy(sample[field])
 
-            if isinstance(samples[0][field], collections.Mapping):
+            if isinstance(samples[0][field], collections.abc.Mapping):
                 self[field] = SampleList(self[field])
 
     def _check_and_load_tuple(self, samples):
@@ -125,7 +125,7 @@ class SampleList(OrderedDict):
             return False
 
     def _check_and_load_dict(self, samples):
-        if isinstance(samples, collections.Mapping):
+        if isinstance(samples, collections.abc.Mapping):
             for key, value in samples.items():
                 self.add_field(key, value)
             return True

--- a/pythia/models/base_model.py
+++ b/pythia/models/base_model.py
@@ -107,7 +107,7 @@ class BaseModel(nn.Module):
         model_output = super().__call__(sample_list, *args, **kwargs)
 
         # Make sure theat the output from the model is a Mapping
-        assert isinstance(model_output, collections.Mapping), (
+        assert isinstance(model_output, collections.abc.Mapping), (
             "A dict must be returned from the forward of the model."
         )
 
@@ -117,7 +117,7 @@ class BaseModel(nn.Module):
                 "No calculation will be done in base model."
             )
             assert isinstance(
-                model_output["losses"], collections.Mapping
+                model_output["losses"], collections.abc.Mapping
             ), "'losses' must be a dict."
         else:
             model_output["losses"] = self.loss(sample_list, model_output)
@@ -128,7 +128,7 @@ class BaseModel(nn.Module):
                 "No calculation will be done in base model."
             )
             assert isinstance(
-                model_output["metrics"], collections.Mapping
+                model_output["metrics"], collections.abc.Mapping
             ), "'metrics' must be a dict."
         else:
             model_output["metrics"] = self.metrics(sample_list, model_output)

--- a/pythia/modules/metrics.py
+++ b/pythia/modules/metrics.py
@@ -76,7 +76,7 @@ class Metrics:
         metrics = {}
         for metric in metric_list:
             params = {}
-            if isinstance(metric, collections.Mapping):
+            if isinstance(metric, collections.abc.Mapping):
                 if not hasattr(metric, "type"):
                     raise ValueError(
                         "Metric {} needs to have 'type' attribute".format(metric)

--- a/pythia/utils/configuration.py
+++ b/pythia/utils/configuration.py
@@ -3,13 +3,12 @@ import collections
 import json
 import os
 import random
-import sys
 from ast import literal_eval
+
+import yaml
 
 import demjson
 import torch
-import yaml
-
 from pythia.common.registry import registry
 from pythia.utils.distributed_utils import is_main_process
 
@@ -22,31 +21,31 @@ class ConfigNode(collections.OrderedDict):
         super().__init__(init_dict)
 
         for key in self:
-            if isinstance(self[key], collections.Mapping):
+            if isinstance(self[key], collections.abc.Mapping):
                 self[key] = ConfigNode(self[key])
             elif isinstance(self[key], list):
                 for idx, item in enumerate(self[key]):
-                    if isinstance(item, collections.Mapping):
+                    if isinstance(item, collections.abc.Mapping):
                         self[key][idx] = ConfigNode(item)
 
     def freeze(self):
         for field in self.keys():
-            if isinstance(self[field], collections.Mapping):
+            if isinstance(self[field], collections.abc.Mapping):
                 self[field].freeze()
             elif isinstance(self[field], list):
                 for item in self[field]:
-                    if isinstance(item, collections.Mapping):
+                    if isinstance(item, collections.abc.Mapping):
                         item.freeze()
 
         self.__dict__[ConfigNode.IMMUTABLE] = True
 
     def defrost(self):
         for field in self.keys():
-            if isinstance(self[field], collections.Mapping):
+            if isinstance(self[field], collections.abc.Mapping):
                 self[field].defrost()
             elif isinstance(self[field], list):
                 for item in self[field]:
-                    if isinstance(item, collections.Mapping):
+                    if isinstance(item, collections.abc.Mapping):
                         item.defrost()
 
         self.__dict__[ConfigNode.IMMUTABLE] = False
@@ -74,7 +73,7 @@ class ConfigNode(collections.OrderedDict):
     def __str__(self):
         strs = []
 
-        if isinstance(self, collections.Mapping):
+        if isinstance(self, collections.abc.Mapping):
             for key, value in sorted(self.items()):
                 seperator = "\n" if isinstance(value, ConfigNode) else " "
                 if isinstance(value, list):
@@ -178,7 +177,7 @@ class Configuration:
             dictionary = {}
 
         for k, v in update.items():
-            if isinstance(v, collections.Mapping):
+            if isinstance(v, collections.abc.Mapping):
                 dictionary[k] = self.nested_dict_update(dictionary.get(k, {}), v)
             else:
                 dictionary[k] = self._decode_value(v)
@@ -206,7 +205,7 @@ class Configuration:
                         " option {} is missing from"
                         " configuration at field {}".format(opt, field)
                     )
-                if not isinstance(current[field], collections.Mapping):
+                if not isinstance(current[field], collections.abc.Mapping):
                     if idx == len(splits) - 1:
                         if is_main_process():
                             print("Overriding option {} to {}".format(opt, value))
@@ -247,7 +246,7 @@ class Configuration:
         any level in 'dictionary'
         """
         for key, value in dictionary.items():
-            if not isinstance(value, collections.Mapping):
+            if not isinstance(value, collections.abc.Mapping):
                 if key in update_dict and update_dict[key] is not None:
                     dictionary[key] = update_dict[key]
             else:


### PR DESCRIPTION
Importing `Mapping` from `collections.abc` as importing the ABCs from `collections` instead of from `collections.abc` is deprecated. 