### PR TITLE
[fix] Extracting object features from gray image

### DIFF
--- a/pythia/scripts/features/extract_features_vmb.py
+++ b/pythia/scripts/features/extract_features_vmb.py
@@ -82,6 +82,9 @@ class FeatureExtractor:
     def _image_transform(self, path):
         img = Image.open(path)
         im = np.array(img).astype(np.float32)
+        # IndexError: too many indices for array
+        if len(im.shape) < 3:
+            im = np.repeat(im[:, :, np.newaxis], 3, axis=2)
         im = im[:, :, ::-1]
         im -= np.array([102.9801, 115.9465, 122.7717])
         im_shape = im.shape


### PR DESCRIPTION
As the shape of gray image is 2D, 
https://github.com/facebookresearch/pythia/blob/0dd1d2f9dac3b2910aa2461e1915b27bc0bb0a4a/pythia/scripts/features/extract_features_vmb.py#L85

line 85 is as shown above will result in an IndexError
```
IndexError: too many indices for array
```