### PR TITLE
Add VQA EvalAI Accuracy metric

### DIFF
--- a/pythia/modules/metrics.py
+++ b/pythia/modules/metrics.py
@@ -49,7 +49,7 @@ import collections
 import torch
 
 from pythia.common.registry import registry
-from pythia.utils.process_answers import ProcessAnswer
+from pythia.tasks.processors import EvalAIAnswerProcessor
 
 
 class Metrics:
@@ -327,7 +327,7 @@ class VQAEvalAIAccuracy(BaseMetric):
 
     def __init__(self):
         super().__init__("vqa_evalai_accuracy")
-        self.process_for_evalai = ProcessAnswer()
+        self.evalai_answer_processor = EvalAIAnswerProcessor()
 
     def _masked_unk_softmax(self, x, dim, mask_idx):
         x1 = torch.nn.functional.softmax(x, dim=dim)
@@ -365,11 +365,9 @@ class VQAEvalAIAccuracy(BaseMetric):
             else:
                 answer = answer_processor.idx2word(answer_id)
 
-            answer = self.process_for_evalai.process_answer(answer)
+            answer = self.evalai_answer_processor(answer)
 
-            gt_answers = [
-                self.process_for_evalai.process_answer(x) for x in expected[idx]
-            ]
+            gt_answers = [self.evalai_answer_processor(x) for x in expected[idx]]
             gt_answers = list(enumerate(gt_answers))
 
             gt_acc = []

--- a/pythia/tasks/processors.py
+++ b/pythia/tasks/processors.py
@@ -74,6 +74,7 @@ Example::
 """
 import multiprocessing
 import os
+import re
 import warnings
 from collections import Counter
 
@@ -869,7 +870,7 @@ class CaptionProcessor(BaseProcessor):
 
     """
 
-    def __init__(self,  config, *args, **kwargs):
+    def __init__(self, config, *args, **kwargs):
         if not hasattr(config, "vocab"):
             raise AttributeError(
                 "config passed to the processor has no " "attribute vocab"
@@ -890,3 +891,216 @@ class CaptionProcessor(BaseProcessor):
         ]
         caption = " ".join(tokens)
         return {"tokens": tokens, "caption": caption}
+
+
+@registry.register_processor("evalai_answer")
+class EvalAIAnswerProcessor(BaseProcessor):
+    """Processes an answer similar to Eval AI
+
+    """
+
+    CONTRACTIONS = {
+        "aint": "ain't",
+        "arent": "aren't",
+        "cant": "can't",
+        "couldve": "could've",
+        "couldnt": "couldn't",
+        "couldn'tve": "couldn't've",
+        "couldnt've": "couldn't've",
+        "didnt": "didn't",
+        "doesnt": "doesn't",
+        "dont": "don't",
+        "hadnt": "hadn't",
+        "hadnt've": "hadn't've",
+        "hadn'tve": "hadn't've",
+        "hasnt": "hasn't",
+        "havent": "haven't",
+        "hed": "he'd",
+        "hed've": "he'd've",
+        "he'dve": "he'd've",
+        "hes": "he's",
+        "howd": "how'd",
+        "howll": "how'll",
+        "hows": "how's",
+        "Id've": "I'd've",
+        "I'dve": "I'd've",
+        "Im": "I'm",
+        "Ive": "I've",
+        "isnt": "isn't",
+        "itd": "it'd",
+        "itd've": "it'd've",
+        "it'dve": "it'd've",
+        "itll": "it'll",
+        "let's": "let's",
+        "maam": "ma'am",
+        "mightnt": "mightn't",
+        "mightnt've": "mightn't've",
+        "mightn'tve": "mightn't've",
+        "mightve": "might've",
+        "mustnt": "mustn't",
+        "mustve": "must've",
+        "neednt": "needn't",
+        "notve": "not've",
+        "oclock": "o'clock",
+        "oughtnt": "oughtn't",
+        "ow's'at": "'ow's'at",
+        "'ows'at": "'ow's'at",
+        "'ow'sat": "'ow's'at",
+        "shant": "shan't",
+        "shed've": "she'd've",
+        "she'dve": "she'd've",
+        "she's": "she's",
+        "shouldve": "should've",
+        "shouldnt": "shouldn't",
+        "shouldnt've": "shouldn't've",
+        "shouldn'tve": "shouldn't've",
+        "somebody'd": "somebodyd",
+        "somebodyd've": "somebody'd've",
+        "somebody'dve": "somebody'd've",
+        "somebodyll": "somebody'll",
+        "somebodys": "somebody's",
+        "someoned": "someone'd",
+        "someoned've": "someone'd've",
+        "someone'dve": "someone'd've",
+        "someonell": "someone'll",
+        "someones": "someone's",
+        "somethingd": "something'd",
+        "somethingd've": "something'd've",
+        "something'dve": "something'd've",
+        "somethingll": "something'll",
+        "thats": "that's",
+        "thered": "there'd",
+        "thered've": "there'd've",
+        "there'dve": "there'd've",
+        "therere": "there're",
+        "theres": "there's",
+        "theyd": "they'd",
+        "theyd've": "they'd've",
+        "they'dve": "they'd've",
+        "theyll": "they'll",
+        "theyre": "they're",
+        "theyve": "they've",
+        "twas": "'twas",
+        "wasnt": "wasn't",
+        "wed've": "we'd've",
+        "we'dve": "we'd've",
+        "weve": "we've",
+        "werent": "weren't",
+        "whatll": "what'll",
+        "whatre": "what're",
+        "whats": "what's",
+        "whatve": "what've",
+        "whens": "when's",
+        "whered": "where'd",
+        "wheres": "where's",
+        "whereve": "where've",
+        "whod": "who'd",
+        "whod've": "who'd've",
+        "who'dve": "who'd've",
+        "wholl": "who'll",
+        "whos": "who's",
+        "whove": "who've",
+        "whyll": "why'll",
+        "whyre": "why're",
+        "whys": "why's",
+        "wont": "won't",
+        "wouldve": "would've",
+        "wouldnt": "wouldn't",
+        "wouldnt've": "wouldn't've",
+        "wouldn'tve": "wouldn't've",
+        "yall": "y'all",
+        "yall'll": "y'all'll",
+        "y'allll": "y'all'll",
+        "yall'd've": "y'all'd've",
+        "y'alld've": "y'all'd've",
+        "y'all'dve": "y'all'd've",
+        "youd": "you'd",
+        "youd've": "you'd've",
+        "you'dve": "you'd've",
+        "youll": "you'll",
+        "youre": "you're",
+        "youve": "you've",
+    }
+
+    NUMBER_MAP = {
+        "none": "0",
+        "zero": "0",
+        "one": "1",
+        "two": "2",
+        "three": "3",
+        "four": "4",
+        "five": "5",
+        "six": "6",
+        "seven": "7",
+        "eight": "8",
+        "nine": "9",
+        "ten": "10",
+    }
+    ARTICLES = ["a", "an", "the"]
+    PERIOD_STRIP = re.compile("(?!<=\d)(\.)(?!\d)")
+    COMMA_STRIP = re.compile("(?<=\d)(\,)+(?=\d)")
+    PUNCTUATIONS = [
+        ";",
+        r"/",
+        "[",
+        "]",
+        '"',
+        "{",
+        "}",
+        "(",
+        ")",
+        "=",
+        "+",
+        "\\",
+        "_",
+        "-",
+        ">",
+        "<",
+        "@",
+        "`",
+        ",",
+        "?",
+        "!",
+    ]
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def word_tokenize(self, word):
+        word = word.lower()
+        word = word.replace(",", "").replace("?", "").replace("'s", " 's")
+        return word.strip()
+
+    def process_punctuation(self, in_text):
+        out_text = in_text
+        for p in self.PUNCTUATIONS:
+            if (p + " " in in_text or " " + p in in_text) or (
+                re.search(self.COMMA_STRIP, in_text) is not None
+            ):
+                out_text = out_text.replace(p, "")
+            else:
+                out_text = out_text.replace(p, " ")
+        out_text = self.PERIOD_STRIP.sub("", out_text, re.UNICODE)
+        return out_text
+
+    def process_digit_article(self, in_text):
+        out_text = []
+        temp_text = in_text.lower().split()
+        for word in temp_text:
+            word = self.NUMBER_MAP.setdefault(word, word)
+            if word not in self.ARTICLES:
+                out_text.append(word)
+            else:
+                pass
+        for word_id, word in enumerate(out_text):
+            if word in self.CONTRACTIONS:
+                out_text[word_id] = self.CONTRACTIONS[word]
+        out_text = " ".join(out_text)
+        return out_text
+
+    def __call__(self, item):
+        item = self.word_tokenize(item)
+        item = item.replace("\n", " ").replace("\t", " ").strip()
+        item = self.process_punctuation(item)
+        item = self.process_digit_article(item)
+        return item

--- a/pythia/utils/process_answers.py
+++ b/pythia/utils/process_answers.py
@@ -3,253 +3,49 @@
 import argparse
 import json
 import os
-import re
+
+from pythia.tasks.processors import EvalAIAnswerProcessor
 
 
-class ProcessAnswer:
-    def __init__(self):
-        self.contractions = {
-            "aint": "ain't",
-            "arent": "aren't",
-            "cant": "can't",
-            "couldve": "could've",
-            "couldnt": "couldn't",
-            "couldn'tve": "couldn't've",
-            "couldnt've": "couldn't've",
-            "didnt": "didn't",
-            "doesnt": "doesn't",
-            "dont": "don't",
-            "hadnt": "hadn't",
-            "hadnt've": "hadn't've",
-            "hadn'tve": "hadn't've",
-            "hasnt": "hasn't",
-            "havent": "haven't",
-            "hed": "he'd",
-            "hed've": "he'd've",
-            "he'dve": "he'd've",
-            "hes": "he's",
-            "howd": "how'd",
-            "howll": "how'll",
-            "hows": "how's",
-            "Id've": "I'd've",
-            "I'dve": "I'd've",
-            "Im": "I'm",
-            "Ive": "I've",
-            "isnt": "isn't",
-            "itd": "it'd",
-            "itd've": "it'd've",
-            "it'dve": "it'd've",
-            "itll": "it'll",
-            "let's": "let's",
-            "maam": "ma'am",
-            "mightnt": "mightn't",
-            "mightnt've": "mightn't've",
-            "mightn'tve": "mightn't've",
-            "mightve": "might've",
-            "mustnt": "mustn't",
-            "mustve": "must've",
-            "neednt": "needn't",
-            "notve": "not've",
-            "oclock": "o'clock",
-            "oughtnt": "oughtn't",
-            "ow's'at": "'ow's'at",
-            "'ows'at": "'ow's'at",
-            "'ow'sat": "'ow's'at",
-            "shant": "shan't",
-            "shed've": "she'd've",
-            "she'dve": "she'd've",
-            "she's": "she's",
-            "shouldve": "should've",
-            "shouldnt": "shouldn't",
-            "shouldnt've": "shouldn't've",
-            "shouldn'tve": "shouldn't've",
-            "somebody'd": "somebodyd",
-            "somebodyd've": "somebody'd've",
-            "somebody'dve": "somebody'd've",
-            "somebodyll": "somebody'll",
-            "somebodys": "somebody's",
-            "someoned": "someone'd",
-            "someoned've": "someone'd've",
-            "someone'dve": "someone'd've",
-            "someonell": "someone'll",
-            "someones": "someone's",
-            "somethingd": "something'd",
-            "somethingd've": "something'd've",
-            "something'dve": "something'd've",
-            "somethingll": "something'll",
-            "thats": "that's",
-            "thered": "there'd",
-            "thered've": "there'd've",
-            "there'dve": "there'd've",
-            "therere": "there're",
-            "theres": "there's",
-            "theyd": "they'd",
-            "theyd've": "they'd've",
-            "they'dve": "they'd've",
-            "theyll": "they'll",
-            "theyre": "they're",
-            "theyve": "they've",
-            "twas": "'twas",
-            "wasnt": "wasn't",
-            "wed've": "we'd've",
-            "we'dve": "we'd've",
-            "weve": "we've",
-            "werent": "weren't",
-            "whatll": "what'll",
-            "whatre": "what're",
-            "whats": "what's",
-            "whatve": "what've",
-            "whens": "when's",
-            "whered": "where'd",
-            "wheres": "where's",
-            "whereve": "where've",
-            "whod": "who'd",
-            "whod've": "who'd've",
-            "who'dve": "who'd've",
-            "wholl": "who'll",
-            "whos": "who's",
-            "whove": "who've",
-            "whyll": "why'll",
-            "whyre": "why're",
-            "whys": "why's",
-            "wont": "won't",
-            "wouldve": "would've",
-            "wouldnt": "wouldn't",
-            "wouldnt've": "wouldn't've",
-            "wouldn'tve": "wouldn't've",
-            "yall": "y'all",
-            "yall'll": "y'all'll",
-            "y'allll": "y'all'll",
-            "yall'd've": "y'all'd've",
-            "y'alld've": "y'all'd've",
-            "y'all'dve": "y'all'd've",
-            "youd": "you'd",
-            "youd've": "you'd've",
-            "you'dve": "you'd've",
-            "youll": "you'll",
-            "youre": "you're",
-            "youve": "you've",
-        }
+def get_score(occurences):
+    if occurences == 0:
+        return 0
+    elif occurences == 1:
+        return 0.3
+    elif occurences == 2:
+        return 0.6
+    elif occurences == 3:
+        return 0.9
+    else:
+        return 1
 
-        self.manual_map = {
-            "none": "0",
-            "zero": "0",
-            "one": "1",
-            "two": "2",
-            "three": "3",
-            "four": "4",
-            "five": "5",
-            "six": "6",
-            "seven": "7",
-            "eight": "8",
-            "nine": "9",
-            "ten": "10",
-        }
-        self.articles = ["a", "an", "the"]
-        self.period_strip = re.compile("(?!<=\d)(\.)(?!\d)")
-        self.comma_strip = re.compile("(?<=\d)(\,)+(?=\d)")
-        self.punct = [
-            ";",
-            r"/",
-            "[",
-            "]",
-            '"',
-            "{",
-            "}",
-            "(",
-            ")",
-            "=",
-            "+",
-            "\\",
-            "_",
-            "-",
-            ">",
-            "<",
-            "@",
-            "`",
-            ",",
-            "?",
-            "!",
-        ]
 
-    def word_tokenize(self, word):
-        word = word.lower()
-        word = word.replace(",", "").replace("?", "").replace("'s", " 's")
-        return word.strip()
+def multiple_replace(text, wordDict):
+    for key in wordDict:
+        text = text.replace(key, wordDict[key])
+    return text
 
-    def process_punctuation(self, inText):
-        outText = inText
-        for p in self.punct:
-            if (p + " " in inText or " " + p in inText) or (
-                re.search(self.comma_strip, inText) is not None
-            ):
-                outText = outText.replace(p, "")
-            else:
-                outText = outText.replace(p, " ")
-        outText = self.period_strip.sub("", outText, re.UNICODE)
-        return outText
 
-    def process_digit_article(self, inText):
-        outText = []
-        tempText = inText.lower().split()
-        for word in tempText:
-            word = self.manual_map.setdefault(word, word)
-            if word not in self.articles:
-                outText.append(word)
-            else:
-                pass
-        for wordId, word in enumerate(outText):
-            if word in self.contractions:
-                outText[wordId] = self.contractions[word]
-        outText = " ".join(outText)
-        return outText
+def filter_answers(answers_dset, min_occurence):
+    """This will change the answer to preprocessed version
+    """
+    occurence = {}
+    answer_list = []
+    evalai_answer_processor = EvalAIAnswerProcessor()
+    for ans_entry in answers_dset:
+        gtruth = ans_entry["multiple_choice_answer"]
+        gtruth = evalai_answer_processor(gtruth)
+        if gtruth not in occurence:
+            occurence[gtruth] = set()
+        occurence[gtruth].add(ans_entry["question_id"])
+    for answer in occurence.keys():
+        if len(occurence[answer]) >= min_occurence:
+            answer_list.append(answer)
 
-    def process_answer(self, answer):
-        answer = self.word_tokenize(answer)
-        answer = answer.replace("\n", " ")
-        answer = answer.replace("\t", " ")
-        answer = answer.strip()
-        answer = self.process_punctuation(answer)
-        answer = self.process_digit_article(answer)
-        return answer
-
-    def get_score(self, occurences):
-        if occurences == 0:
-            return 0
-        elif occurences == 1:
-            return 0.3
-        elif occurences == 2:
-            return 0.6
-        elif occurences == 3:
-            return 0.9
-        else:
-            return 1
-
-    def multiple_replace(self, text, wordDict):
-        for key in wordDict:
-            text = text.replace(key, wordDict[key])
-        return text
-
-    def filter_answers(self, answers_dset, min_occurence):
-        """This will change the answer to preprocessed version
-        """
-        occurence = {}
-        answer_list = []
-        for ans_entry in answers_dset:
-            gtruth = ans_entry["multiple_choice_answer"]
-            gtruth = self.process_answer(gtruth)
-            if gtruth not in occurence:
-                occurence[gtruth] = set()
-            occurence[gtruth].add(ans_entry["question_id"])
-        for answer in occurence.keys():
-            if len(occurence[answer]) >= min_occurence:
-                answer_list.append(answer)
-
-        print(
-            "Num of answers that appear >= %d times: %d"
-            % (min_occurence, len(answer_list))
-        )
-        return answer_list
+    print(
+        "Num of answers that appear >= %d times: %d" % (min_occurence, len(answer_list))
+    )
+    return answer_list
 
 
 if __name__ == "__main__":
@@ -296,8 +92,7 @@ if __name__ == "__main__":
         val_answers = json.load(open(val_annotation_file, "r"))["annotations"]
         answers = train_answers + val_answers
 
-    answer_processor = ProcessAnswer()
-    answer_list = answer_processor.filter_answers(answers, min_freq)
+    answer_list = filter_answers(answers, min_freq)
     answer_list = [t.strip() for t in answer_list if len(t.strip()) > 0]
     answer_list.sort()
 

--- a/pythia/utils/process_answers.py
+++ b/pythia/utils/process_answers.py
@@ -5,244 +5,251 @@ import json
 import os
 import re
 
-contractions = {
-    "aint": "ain't",
-    "arent": "aren't",
-    "cant": "can't",
-    "couldve": "could've",
-    "couldnt": "couldn't",
-    "couldn'tve": "couldn't've",
-    "couldnt've": "couldn't've",
-    "didnt": "didn't",
-    "doesnt": "doesn't",
-    "dont": "don't",
-    "hadnt": "hadn't",
-    "hadnt've": "hadn't've",
-    "hadn'tve": "hadn't've",
-    "hasnt": "hasn't",
-    "havent": "haven't",
-    "hed": "he'd",
-    "hed've": "he'd've",
-    "he'dve": "he'd've",
-    "hes": "he's",
-    "howd": "how'd",
-    "howll": "how'll",
-    "hows": "how's",
-    "Id've": "I'd've",
-    "I'dve": "I'd've",
-    "Im": "I'm",
-    "Ive": "I've",
-    "isnt": "isn't",
-    "itd": "it'd",
-    "itd've": "it'd've",
-    "it'dve": "it'd've",
-    "itll": "it'll",
-    "let's": "let's",
-    "maam": "ma'am",
-    "mightnt": "mightn't",
-    "mightnt've": "mightn't've",
-    "mightn'tve": "mightn't've",
-    "mightve": "might've",
-    "mustnt": "mustn't",
-    "mustve": "must've",
-    "neednt": "needn't",
-    "notve": "not've",
-    "oclock": "o'clock",
-    "oughtnt": "oughtn't",
-    "ow's'at": "'ow's'at",
-    "'ows'at": "'ow's'at",
-    "'ow'sat": "'ow's'at",
-    "shant": "shan't",
-    "shed've": "she'd've",
-    "she'dve": "she'd've",
-    "she's": "she's",
-    "shouldve": "should've",
-    "shouldnt": "shouldn't",
-    "shouldnt've": "shouldn't've",
-    "shouldn'tve": "shouldn't've",
-    "somebody'd": "somebodyd",
-    "somebodyd've": "somebody'd've",
-    "somebody'dve": "somebody'd've",
-    "somebodyll": "somebody'll",
-    "somebodys": "somebody's",
-    "someoned": "someone'd",
-    "someoned've": "someone'd've",
-    "someone'dve": "someone'd've",
-    "someonell": "someone'll",
-    "someones": "someone's",
-    "somethingd": "something'd",
-    "somethingd've": "something'd've",
-    "something'dve": "something'd've",
-    "somethingll": "something'll",
-    "thats": "that's",
-    "thered": "there'd",
-    "thered've": "there'd've",
-    "there'dve": "there'd've",
-    "therere": "there're",
-    "theres": "there's",
-    "theyd": "they'd",
-    "theyd've": "they'd've",
-    "they'dve": "they'd've",
-    "theyll": "they'll",
-    "theyre": "they're",
-    "theyve": "they've",
-    "twas": "'twas",
-    "wasnt": "wasn't",
-    "wed've": "we'd've",
-    "we'dve": "we'd've",
-    "weve": "we've",
-    "werent": "weren't",
-    "whatll": "what'll",
-    "whatre": "what're",
-    "whats": "what's",
-    "whatve": "what've",
-    "whens": "when's",
-    "whered": "where'd",
-    "wheres": "where's",
-    "whereve": "where've",
-    "whod": "who'd",
-    "whod've": "who'd've",
-    "who'dve": "who'd've",
-    "wholl": "who'll",
-    "whos": "who's",
-    "whove": "who've",
-    "whyll": "why'll",
-    "whyre": "why're",
-    "whys": "why's",
-    "wont": "won't",
-    "wouldve": "would've",
-    "wouldnt": "wouldn't",
-    "wouldnt've": "wouldn't've",
-    "wouldn'tve": "wouldn't've",
-    "yall": "y'all",
-    "yall'll": "y'all'll",
-    "y'allll": "y'all'll",
-    "yall'd've": "y'all'd've",
-    "y'alld've": "y'all'd've",
-    "y'all'dve": "y'all'd've",
-    "youd": "you'd",
-    "youd've": "you'd've",
-    "you'dve": "you'd've",
-    "youll": "you'll",
-    "youre": "you're",
-    "youve": "you've",
-}
 
-manual_map = {
-    "none": "0",
-    "zero": "0",
-    "one": "1",
-    "two": "2",
-    "three": "3",
-    "four": "4",
-    "five": "5",
-    "six": "6",
-    "seven": "7",
-    "eight": "8",
-    "nine": "9",
-    "ten": "10",
-}
-articles = ["a", "an", "the"]
-period_strip = re.compile("(?!<=\d)(\.)(?!\d)")
-comma_strip = re.compile("(\d)(\,)(\d)")
-punct = [
-    ";",
-    r"/",
-    "[",
-    "]",
-    '"',
-    "{",
-    "}",
-    "(",
-    ")",
-    "=",
-    "+",
-    "\\",
-    "_",
-    "-",
-    ">",
-    "<",
-    "@",
-    "`",
-    ",",
-    "?",
-    "!",
-]
+class ProcessAnswer:
+    def __init__(self):
+        self.contractions = {
+            "aint": "ain't",
+            "arent": "aren't",
+            "cant": "can't",
+            "couldve": "could've",
+            "couldnt": "couldn't",
+            "couldn'tve": "couldn't've",
+            "couldnt've": "couldn't've",
+            "didnt": "didn't",
+            "doesnt": "doesn't",
+            "dont": "don't",
+            "hadnt": "hadn't",
+            "hadnt've": "hadn't've",
+            "hadn'tve": "hadn't've",
+            "hasnt": "hasn't",
+            "havent": "haven't",
+            "hed": "he'd",
+            "hed've": "he'd've",
+            "he'dve": "he'd've",
+            "hes": "he's",
+            "howd": "how'd",
+            "howll": "how'll",
+            "hows": "how's",
+            "Id've": "I'd've",
+            "I'dve": "I'd've",
+            "Im": "I'm",
+            "Ive": "I've",
+            "isnt": "isn't",
+            "itd": "it'd",
+            "itd've": "it'd've",
+            "it'dve": "it'd've",
+            "itll": "it'll",
+            "let's": "let's",
+            "maam": "ma'am",
+            "mightnt": "mightn't",
+            "mightnt've": "mightn't've",
+            "mightn'tve": "mightn't've",
+            "mightve": "might've",
+            "mustnt": "mustn't",
+            "mustve": "must've",
+            "neednt": "needn't",
+            "notve": "not've",
+            "oclock": "o'clock",
+            "oughtnt": "oughtn't",
+            "ow's'at": "'ow's'at",
+            "'ows'at": "'ow's'at",
+            "'ow'sat": "'ow's'at",
+            "shant": "shan't",
+            "shed've": "she'd've",
+            "she'dve": "she'd've",
+            "she's": "she's",
+            "shouldve": "should've",
+            "shouldnt": "shouldn't",
+            "shouldnt've": "shouldn't've",
+            "shouldn'tve": "shouldn't've",
+            "somebody'd": "somebodyd",
+            "somebodyd've": "somebody'd've",
+            "somebody'dve": "somebody'd've",
+            "somebodyll": "somebody'll",
+            "somebodys": "somebody's",
+            "someoned": "someone'd",
+            "someoned've": "someone'd've",
+            "someone'dve": "someone'd've",
+            "someonell": "someone'll",
+            "someones": "someone's",
+            "somethingd": "something'd",
+            "somethingd've": "something'd've",
+            "something'dve": "something'd've",
+            "somethingll": "something'll",
+            "thats": "that's",
+            "thered": "there'd",
+            "thered've": "there'd've",
+            "there'dve": "there'd've",
+            "therere": "there're",
+            "theres": "there's",
+            "theyd": "they'd",
+            "theyd've": "they'd've",
+            "they'dve": "they'd've",
+            "theyll": "they'll",
+            "theyre": "they're",
+            "theyve": "they've",
+            "twas": "'twas",
+            "wasnt": "wasn't",
+            "wed've": "we'd've",
+            "we'dve": "we'd've",
+            "weve": "we've",
+            "werent": "weren't",
+            "whatll": "what'll",
+            "whatre": "what're",
+            "whats": "what's",
+            "whatve": "what've",
+            "whens": "when's",
+            "whered": "where'd",
+            "wheres": "where's",
+            "whereve": "where've",
+            "whod": "who'd",
+            "whod've": "who'd've",
+            "who'dve": "who'd've",
+            "wholl": "who'll",
+            "whos": "who's",
+            "whove": "who've",
+            "whyll": "why'll",
+            "whyre": "why're",
+            "whys": "why's",
+            "wont": "won't",
+            "wouldve": "would've",
+            "wouldnt": "wouldn't",
+            "wouldnt've": "wouldn't've",
+            "wouldn'tve": "wouldn't've",
+            "yall": "y'all",
+            "yall'll": "y'all'll",
+            "y'allll": "y'all'll",
+            "yall'd've": "y'all'd've",
+            "y'alld've": "y'all'd've",
+            "y'all'dve": "y'all'd've",
+            "youd": "you'd",
+            "youd've": "you'd've",
+            "you'dve": "you'd've",
+            "youll": "you'll",
+            "youre": "you're",
+            "youve": "you've",
+        }
 
+        self.manual_map = {
+            "none": "0",
+            "zero": "0",
+            "one": "1",
+            "two": "2",
+            "three": "3",
+            "four": "4",
+            "five": "5",
+            "six": "6",
+            "seven": "7",
+            "eight": "8",
+            "nine": "9",
+            "ten": "10",
+        }
+        self.articles = ["a", "an", "the"]
+        self.period_strip = re.compile("(?!<=\d)(\.)(?!\d)")
+        self.comma_strip = re.compile("(?<=\d)(\,)+(?=\d)")
+        self.punct = [
+            ";",
+            r"/",
+            "[",
+            "]",
+            '"',
+            "{",
+            "}",
+            "(",
+            ")",
+            "=",
+            "+",
+            "\\",
+            "_",
+            "-",
+            ">",
+            "<",
+            "@",
+            "`",
+            ",",
+            "?",
+            "!",
+        ]
 
-def get_score(occurences):
-    if occurences == 0:
-        return 0
-    elif occurences == 1:
-        return 0.3
-    elif occurences == 2:
-        return 0.6
-    elif occurences == 3:
-        return 0.9
-    else:
-        return 1
+    def word_tokenize(self, word):
+        word = word.lower()
+        word = word.replace(",", "").replace("?", "").replace("'s", " 's")
+        return word.strip()
 
+    def process_punctuation(self, inText):
+        outText = inText
+        for p in self.punct:
+            if (p + " " in inText or " " + p in inText) or (
+                re.search(self.comma_strip, inText) is not None
+            ):
+                outText = outText.replace(p, "")
+            else:
+                outText = outText.replace(p, " ")
+        outText = self.period_strip.sub("", outText, re.UNICODE)
+        return outText
 
-def process_punctuation(inText):
-    outText = inText
-    for p in punct:
-        if (p + " " in inText or " " + p in inText) or (
-            re.search(comma_strip, inText) is not None
-        ):
-            outText = outText.replace(p, "")
+    def process_digit_article(self, inText):
+        outText = []
+        tempText = inText.lower().split()
+        for word in tempText:
+            word = self.manual_map.setdefault(word, word)
+            if word not in self.articles:
+                outText.append(word)
+            else:
+                pass
+        for wordId, word in enumerate(outText):
+            if word in self.contractions:
+                outText[wordId] = self.contractions[word]
+        outText = " ".join(outText)
+        return outText
+
+    def process_answer(self, answer):
+        answer = self.word_tokenize(answer)
+        answer = answer.replace("\n", " ")
+        answer = answer.replace("\t", " ")
+        answer = answer.strip()
+        answer = self.process_punctuation(answer)
+        answer = self.process_digit_article(answer)
+        return answer
+
+    def get_score(self, occurences):
+        if occurences == 0:
+            return 0
+        elif occurences == 1:
+            return 0.3
+        elif occurences == 2:
+            return 0.6
+        elif occurences == 3:
+            return 0.9
         else:
-            outText = outText.replace(p, " ")
-    outText = period_strip.sub("", outText, re.UNICODE)
-    return outText
+            return 1
 
+    def multiple_replace(self, text, wordDict):
+        for key in wordDict:
+            text = text.replace(key, wordDict[key])
+        return text
 
-def process_digit_article(inText):
-    outText = []
-    tempText = inText.lower().split()
-    for word in tempText:
-        word = manual_map.setdefault(word, word)
-        if word not in articles:
-            outText.append(word)
-        else:
-            pass
-    for wordId, word in enumerate(outText):
-        if word in contractions:
-            outText[wordId] = contractions[word]
-    outText = " ".join(outText)
-    return outText
+    def filter_answers(self, answers_dset, min_occurence):
+        """This will change the answer to preprocessed version
+        """
+        occurence = {}
+        answer_list = []
+        for ans_entry in answers_dset:
+            gtruth = ans_entry["multiple_choice_answer"]
+            gtruth = self.process_answer(gtruth)
+            if gtruth not in occurence:
+                occurence[gtruth] = set()
+            occurence[gtruth].add(ans_entry["question_id"])
+        for answer in occurence.keys():
+            if len(occurence[answer]) >= min_occurence:
+                answer_list.append(answer)
 
-
-def multiple_replace(text, wordDict):
-    for key in wordDict:
-        text = text.replace(key, wordDict[key])
-    return text
-
-
-def preprocess_answer(answer):
-    answer = process_digit_article(process_punctuation(answer))
-    answer = answer.replace(",", "")
-    return answer
-
-
-def filter_answers(answers_dset, min_occurence):
-    """This will change the answer to preprocessed version
-    """
-    occurence = {}
-    answer_list = []
-    for ans_entry in answers_dset:
-        gtruth = ans_entry["multiple_choice_answer"]
-        gtruth = preprocess_answer(gtruth)
-        if gtruth not in occurence:
-            occurence[gtruth] = set()
-        occurence[gtruth].add(ans_entry["question_id"])
-    for answer in occurence.keys():
-        if len(occurence[answer]) >= min_occurence:
-            answer_list.append(answer)
-
-    print(
-        "Num of answers that appear >= %d times: %d" % (min_occurence, len(answer_list))
-    )
-    return answer_list
+        print(
+            "Num of answers that appear >= %d times: %d"
+            % (min_occurence, len(answer_list))
+        )
+        return answer_list
 
 
 if __name__ == "__main__":
@@ -289,7 +296,8 @@ if __name__ == "__main__":
         val_answers = json.load(open(val_annotation_file, "r"))["annotations"]
         answers = train_answers + val_answers
 
-    answer_list = filter_answers(answers, min_freq)
+    answer_processor = ProcessAnswer()
+    answer_list = answer_processor.filter_answers(answers, min_freq)
     answer_list = [t.strip() for t in answer_list if len(t.strip()) > 0]
     answer_list.sort()
 

--- a/tests/tasks/test_processors.py
+++ b/tests/tasks/test_processors.py
@@ -5,7 +5,11 @@ import unittest
 import yaml
 import torch
 
-from pythia.tasks.processors import CaptionProcessor, MultiHotAnswerFromVocabProcessor
+from pythia.tasks.processors import (
+    CaptionProcessor,
+    MultiHotAnswerFromVocabProcessor,
+    EvalAIAnswerProcessor,
+)
 from pythia.utils.configuration import ConfigNode
 
 from ..test_utils import compare_tensors
@@ -26,7 +30,9 @@ class TestTaskProcessors(unittest.TestCase):
         captioning_config = config.task_attributes.captioning.dataset_attributes.coco
         caption_processor_config = captioning_config.processors.caption_processor
 
-        vocab_path = os.path.join(os.path.abspath(__file__), "..", "..", "data", "vocab.txt")
+        vocab_path = os.path.join(
+            os.path.abspath(__file__), "..", "..", "data", "vocab.txt"
+        )
         caption_processor_config.params.vocab.vocab_file = os.path.abspath(vocab_path)
         caption_processor = CaptionProcessor(caption_processor_config.params)
 
@@ -34,26 +40,34 @@ class TestTaskProcessors(unittest.TestCase):
         caption = caption_processor(tokens)
 
         # Test start, stop, pad are removed
-        self.assertNotIn('<s>', caption["tokens"])
-        self.assertNotIn('</s>', caption["tokens"])
-        self.assertNotIn('<pad>', caption["tokens"])
+        self.assertNotIn("<s>", caption["tokens"])
+        self.assertNotIn("</s>", caption["tokens"])
+        self.assertNotIn("<pad>", caption["tokens"])
 
         # Test caption is correct
         self.assertEqual(caption["caption"], "a man with a red helmet")
 
     def test_multi_hot_answer_from_vocab_processor(self):
-        config = self._get_config("../../../pythia/common/defaults/configs/tasks/vqa/clevr.yml")
+        config = self._get_config(
+            "../../../pythia/common/defaults/configs/tasks/vqa/clevr.yml"
+        )
         clevr_config = config.task_attributes.vqa.dataset_attributes.clevr
         answer_processor_config = clevr_config.processors.answer_processor
 
         # Test num_answers==1 case
-        vocab_path = os.path.join(os.path.abspath(__file__), "..", "..", "data", "vocab.txt")
+        vocab_path = os.path.join(
+            os.path.abspath(__file__), "..", "..", "data", "vocab.txt"
+        )
         answer_processor_config.params.vocab_file = os.path.abspath(vocab_path)
-        answer_processor = MultiHotAnswerFromVocabProcessor(answer_processor_config.params)
+        answer_processor = MultiHotAnswerFromVocabProcessor(
+            answer_processor_config.params
+        )
         processed = answer_processor({"answers": ["helmet"]})
         answers_indices = processed["answers_indices"]
         answers_scores = processed["answers_scores"]
-        self.assertTrue(compare_tensors(answers_indices, torch.tensor([5], dtype=torch.long)))
+        self.assertTrue(
+            compare_tensors(answers_indices, torch.tensor([5], dtype=torch.long))
+        )
         expected_answers_scores = torch.zeros(19, dtype=torch.float)
         expected_answers_scores[5] = 1.0
         self.assertTrue(compare_tensors(answers_scores, expected_answers_scores))
@@ -61,13 +75,15 @@ class TestTaskProcessors(unittest.TestCase):
         # Test multihot when num answers greater than 1
         answer_processor_config.params.vocab_file = os.path.abspath(vocab_path)
         answer_processor_config.params.num_answers = 3
-        answer_processor = MultiHotAnswerFromVocabProcessor(answer_processor_config.params)
+        answer_processor = MultiHotAnswerFromVocabProcessor(
+            answer_processor_config.params
+        )
         processed = answer_processor({"answers": ["man", "with", "countryside"]})
         answers_indices = processed["answers_indices"]
         answers_scores = processed["answers_scores"]
-        self.assertTrue(compare_tensors(
-            answers_indices, torch.tensor([2, 3, 15], dtype=torch.long)
-        ))
+        self.assertTrue(
+            compare_tensors(answers_indices, torch.tensor([2, 3, 15], dtype=torch.long))
+        )
         expected_answers_scores = torch.zeros(19, dtype=torch.float)
         expected_answers_scores[2] = 1.0
         expected_answers_scores[3] = 1.0
@@ -78,10 +94,38 @@ class TestTaskProcessors(unittest.TestCase):
         processed = answer_processor({"answers": ["test", "answer", "man"]})
         answers_indices = processed["answers_indices"]
         answers_scores = processed["answers_scores"]
-        self.assertTrue(compare_tensors(
-            answers_indices, torch.tensor([0, 0, 2], dtype=torch.long)
-        ))
+        self.assertTrue(
+            compare_tensors(answers_indices, torch.tensor([0, 0, 2], dtype=torch.long))
+        )
         print(answers_indices, answers_scores)
         expected_answers_scores = torch.zeros(19, dtype=torch.float)
         expected_answers_scores[2] = 1.0
         self.assertTrue(compare_tensors(answers_scores, expected_answers_scores))
+
+    def test_evalai_answer_processor(self):
+        evalai_answer_processor = EvalAIAnswerProcessor()
+
+        # Test number
+        processed = evalai_answer_processor("two")
+        expected = "2"
+        self.assertEqual(processed, expected)
+
+        # Test article
+        processed = evalai_answer_processor("a building")
+        expected = "building"
+        self.assertEqual(processed, expected)
+
+        # Test tokenize
+        processed = evalai_answer_processor("snow, mountain")
+        expected = "snow mountain"
+        self.assertEqual(processed, expected)
+
+        # Test contractions
+        processed = evalai_answer_processor("isnt")
+        expected = "isn't"
+        self.assertEqual(processed, expected)
+
+        # Test processor
+        processed = evalai_answer_processor("the two mountain's \t \n   ")
+        expected = "2 mountain 's"
+        self.assertEqual(processed, expected)


### PR DESCRIPTION
Adding VQA Eval AI Accuracy `vqa_evalai_accuracy`  metric which is close to the accuracy calculation method in Eval AI. However this is slower compared to VQA Accuracy `vqa_accuracy` since it loops over and processes the answers before calculating the accuracy with the ground truth. Fixes #109.